### PR TITLE
Change base pytorch tag to rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm7.1.1_ubuntu24.04_py3.12_pytorch_release_2.9.1
+FROM rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.8.0
 
 # "Installing" flash-attention
 # - Not sure if branch `main_perf` is actually better,


### PR DESCRIPTION
This bumps the rocm version to account for the bug referenced [here](https://github.com/ROCm/TheRock/issues/2991#issuecomment-3768808325).

I have not been able to perform thorough testing but I have confirmed that ComfyUI runs and I'm able to run a workflow as well as pass the tests provided in the utils directory of this repository. 

I've included the output of those here:
```
root@be93252720ae:/opt/comfyui-gfx1151-utils# ./test-pytorch.sh 
GPU: AMD Radeon Graphics | FlashAttn: True
Mean: -0.031567081809043884
```
```
root@be93252720ae:/opt/comfyui-gfx1151-utils# ./test-pytorch-flashattention.py 
=== PyTorch Installation Check ===
PyTorch version: 2.8.0+rocm7.2.0.gitbf943426
PyTorch ROCm version: 7.2.26015-fc0010cf6a
CUDA available: True
Device count: 1
Device name: AMD Radeon Graphics

=== Flash Attention Support Check ===
/usr/lib/python3.12/contextlib.py:105: FutureWarning: `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the new context manager, with updated signature.
  self.gen = func(*args, **kwds)
Available SDP backends: <contextlib._GeneratorContextManager object at 0x7ff23b702e10>
Flash Attention backend enabled
Test tensors created on cuda
Flash Attention test successful! Output shape: torch.Size([2, 8, 128, 64])

=== AOTriton Check ===
AOTriton not available: No module named 'pyaotriton'

=== Environment Variables ===
ROCM_PATH: Not set
HIP_PATH: Not set
HIP_PLATFORM: Not set
HIP_ARCH: Not set
HSA_OVERRIDE_GFX_VERSION: Not set

=== Testing GFX Version Override ===
Set HSA_OVERRIDE_GFX_VERSION=11.0.0 to test gfx110x mapping
✓ Flash Attention worked with GFX override!

=== Flash Attention Backend Detection ===
✓ flash backend works
✓ mem_efficient backend works
✓ math backend works
```