### PR TITLE
Add COMFYUI_VERSION build arg, ComfyUI Manager, and fully qualified base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
+FROM docker.io/rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
 
 # "Installing" flash-attention
 # - Not sure if branch `main_perf` is actually better,

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,18 @@ RUN cd /opt && \
     git checkout main_perf && \
     python setup.py install
 
-# Cloning and installing ComfyUI in case the user doesn't provide their own
-# - Nothing unusual here afaik
+# Cloning and installing ComfyUI in case the user doesn't provide their own.
+# COMFYUI_VERSION pins the release tag (e.g. v0.18.2).
+# Manager requirements are installed so that --enable-manager works at runtime.
+
+ARG COMFYUI_VERSION=v0.18.2
 
 RUN cd /opt && \
     git clone https://github.com/comfyanonymous/ComfyUI ComfyUI-pre-cloned && \
     cd ComfyUI-pre-cloned && \
-    pip3 install -r requirements.txt
+    git checkout ${COMFYUI_VERSION} && \
+    pip3 install -r requirements.txt && \
+    pip3 install -r manager_requirements.txt
 
 # Some utilities to make life/debugging easier
 # Feel free to remove these if you're building from scratch locally.
@@ -46,4 +51,4 @@ RUN chmod +x test-pytorch-flashattention.py
 
 EXPOSE 8188
 
-CMD /opt/comfyui-gfx1151-utils/check-comfyui.sh && python3 /opt/ComfyUI/main.py --listen 0.0.0.0 --use-flash-attention --gpu-only
+CMD /opt/comfyui-gfx1151-utils/check-comfyui.sh && python3 /opt/ComfyUI/main.py --listen 0.0.0.0 --use-flash-attention --gpu-only --enable-manager


### PR DESCRIPTION
### Disclaimer
Code changes and PR message created using Claude Code.
The new version works on my Framework Desktop AI Max 395 identical to version 0.2.

### Summary
- **Version pinning**: `COMFYUI_VERSION` build arg (default `v0.18.2`) checks out a specific release tag instead of tracking `master`, making builds reproducible.
- **ComfyUI Manager**: installs `manager_requirements.txt` and adds `--enable-manager` to CMD so the built-in [ComfyUI Manager](https://github.com/Comfy-Org/ComfyUI-Manager) works out of the box.
- **Fully qualified base image**: `docker.io/rocm/pytorch:...` prevents Podman's short-name resolution failure in non-interactive builds (Ansible, CI).
### Usage
```bash
# Pinned stable release (default)
podman build -t comfyui-gfx1151:v0.18.2 .
# Specific version
podman build --build-arg COMFYUI_VERSION=v0.17.0 -t comfyui-gfx1151:v0.17.0 .
# Latest development
podman build --build-arg COMFYUI_VERSION=master -t comfyui-gfx1151:latest .
```

### Backward compatibility
Building without `--build-arg` now produces a pinned image rather than tracking master. The `docker.io/` prefix is functionally identical on systems with Docker Hub as the default registry. `--enable-manager` activates the Manager UI but does not change core ComfyUI behaviour.


